### PR TITLE
Bugfix in Delete: fix deadlock in the connection pool

### DIFF
--- a/pgdriver/driver.go
+++ b/pgdriver/driver.go
@@ -440,6 +440,9 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 			}
 		}
 	}
+	if err = tx.Commit(); err != nil {
+		return err
+	}
 
 	for _, key := range deleted {
 		if err := d.storage.Delete(ctx, key); err != nil {
@@ -448,7 +451,7 @@ func (d *driver) Delete(ctx context.Context, path string) error {
 	}
 
 	// TODO: mark fields in MDS table before commit from `deleted` array
-	return tx.Commit()
+	return nil
 }
 
 // URLFor returns a URL which may be used to retrieve the content stored at

--- a/pgdriver/mds.go
+++ b/pgdriver/mds.go
@@ -118,6 +118,7 @@ func (m *mdsBinStorage) Delete(ctx context.Context, key string) error {
 	_, err = m.DB(pgcluster.MASTER).Exec("UPDATE mds SET deleted = true WHERE (key = $1)", key)
 	if err != nil {
 		context.GetLogger(ctx).Errorf("update metainfo about deleted key %s error: %v", key, err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
BinaryStorage operations can use a DB connection, so move Delete operation out of Tx
